### PR TITLE
update dependencies to build from mvnrepository.com

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,13 +176,13 @@
     <dependency>
       <groupId>com.outbrain.swinfra</groupId>
       <artifactId>util-metrics</artifactId>
-      <version>0.45</version>
+      <version>0.122</version>
     </dependency>
 
     <dependency>
       <groupId>com.outbrain.swinfra</groupId>
       <artifactId>util-config</artifactId>
-      <version>0.45</version>
+      <version>0.122</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Hi,

This is a pull request to use new version for some utils dependencies: util-metrics and util-config. Those 2 artifacts are available in mvnrepository.com only in (what I guess) the latest version: 0.122.

Regards,

Nicolas